### PR TITLE
docs: Add documentation for the Persian Paxos paper

### DIFF
--- a/Paxos/Persian_Doc/README.md
+++ b/Paxos/Persian_Doc/README.md
@@ -1,0 +1,25 @@
+# Persian Documentation for Paxos with TLA+
+
+This directory contains a paper on the Paxos algorithm, written in Persian. The paper details an implementation of Paxos using TLA+ and appears to be a university project.
+
+## Contents
+
+- `Paxos.tex`: The main LaTeX source file for the paper.
+- `neurips.sty`: A LaTeX style file used for formatting.
+- `Photos/`: A directory containing images included in the paper.
+- `*.ttf`: Font files (XB Yas) required to compile the document.
+
+## Compiling the Document
+
+To generate a PDF from the source files, you will need a LaTeX distribution that supports `xepersian` (e.g., TeX Live). Due to the use of custom fonts, you must compile the document using `xelatex`.
+
+Run the following command in this directory:
+```bash
+xelatex Paxos.tex
+```
+
+This will produce a `Paxos.pdf` file.
+
+## Disclaimer
+
+This document is a community contribution and is not part of the official "Dr. TLA+ Series" lectures. It was forked from another repository and added here for reference.

--- a/Paxos/README.md
+++ b/Paxos/README.md
@@ -15,6 +15,7 @@ Andrew Helwer is a software engineer in Microsoft Azure, living in Seattle WA. H
 (not required, but helpful to take a look before the lecture)
 + [Paxos Made Simple](http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf)
 + [Paxos TLA+ specification](./Paxos.tla)
++ [Persian paper on Paxos and TLA+](./Persian_Doc/README.md)
 
 ### Media
 + [video](https://www.youtube.com/watch?v=zCaJSrTmUFA)


### PR DESCRIPTION
This commit adds documentation for the Persian-language paper on Paxos and TLA+ located in the `Paxos/Persian_Doc/` directory.

A new `README.md` file has been created in `Paxos/Persian_Doc/` that explains the contents of the directory and provides instructions on how to compile the LaTeX paper to a PDF.

The request to add docstrings to the files was not applicable as the directory contains a LaTeX project, not source code. This new README serves as the primary documentation for this section of the repository.

Additionally, the `Paxos/README.md` file has been updated to include a link to this new documentation, making it more discoverable.